### PR TITLE
Desenvolvimento de um novo endpoint da API de Token JWT

### DIFF
--- a/apps/accounts/api/urls.py
+++ b/apps/accounts/api/urls.py
@@ -1,14 +1,12 @@
 from django.urls import path
-from .views import get_routes, get_cookies_access_token, MyTokenObtainPairView
-
-from rest_framework_simplejwt.views import (
-    TokenRefreshView,
-)
+from .views import MyTokenObtainPairView, refresh_access_token, get_cookies_access_token, get_routes, logout_user
 
 
 urlpatterns = [
     path('', get_routes),
     path('token/', MyTokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('token/refresh/', refresh_access_token, name='token_refresh'),
+    path('api/token/logout/', logout_user, name='logout_user'),
     path('token/get-cookies-token', get_cookies_access_token, name='get_cookies_token'),
+    
 ]

--- a/apps/accounts/api/views.py
+++ b/apps/accounts/api/views.py
@@ -3,8 +3,7 @@ from rest_framework import serializers
 from rest_framework.response import Response
 from django.contrib.auth import authenticate
 from rest_framework.decorators import api_view
-
-from rest_framework_simplejwt.tokens import AccessToken
+from rest_framework_simplejwt.tokens import AccessToken, RefreshToken
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.settings import api_settings
 from rest_framework_simplejwt.views import TokenObtainPairView
@@ -81,10 +80,42 @@ def get_cookies_access_token(request):
     
     return Response({'Access_token': access_token}, status=status.HTTP_200_OK)
 
+@api_view(['POST'])
+def refresh_access_token(request):
+    refresh_token = request.COOKIES.get('refresh_token')
+    if not refresh_token:
+        return Response({'detail': 'Refresh token não encontrado'}, status=status.HTTP_401_UNAUTHORIZED)
+
+    try:
+        refresh = RefreshToken(refresh_token)
+        access = refresh.access_token
+        response = Response({'access_token': str(access)}, status=status.HTTP_200_OK)
+        response.set_cookie(
+            key='access_token',
+            value=str(access),
+            httponly=True,
+            secure=True,
+            samesite='None'
+        )
+        return response
+    except TokenError:
+        return Response({'detail': 'Token inválido'}, status=status.HTTP_401_UNAUTHORIZED)
+    
+@api_view(['POST'])
+def logout_user(request):
+    response = Response({'detail': 'Logout successful'}, status=status.HTTP_200_OK)
+    
+    # Remove os cookies de autenticação
+    response.delete_cookie('access_token')
+    response.delete_cookie('refresh_token')
+    
+    return response
+
 @api_view(['GET'])
 def get_routes(request):
     routes = [
         '/api/token',
+        '/api/token/logout',
         '/api/token/refresh',
         '/api/token/get-cookies-token'
     ]


### PR DESCRIPTION
Criando um endpoint novo de logout que consiste em remover os dois token jwt dos cookies HTTP Only da aplicação web e atualizando endpoint ja criado de refresh token, que quando uma requisição POST é realizada, a resposta é de um novo access token diretamente nos cookies, caso o usuário possua um refresh token nos cookies do navegador.